### PR TITLE
replaced mock title + siteName with real title and siteName

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -36,16 +36,17 @@ app.get("/newarticle", async (req, res) => {
   res.render("newarticle", { articleObj, page: "newarticle" });
 });
 
-app.get("/:uuid", async (req, res) => {
-  const url = `https://8rj0xswzt3.execute-api.eu-west-1.amazonaws.com/dev/commentative/${req.params.uuid}`;
-  const result = await axios(url);
-  const articleObj = {
-    content: result.data.articleBody,
-    comments: result.data.comments
-  };
-  console.log(articleObj);
-  res.render("newarticle", { articleObj, page: "newarticle" });
-});
+// app.get("/:uuid", async (req, res) => {
+//   const url = `https://8rj0xswzt3.execute-api.eu-west-1.amazonaws.com/dev/commentative/${req.params.uuid}`;
+//   const result = await axios(url);
+//   const articleObj = {
+//     header: "This is the actual header of the article",
+//     content: result.data.articleBody,
+//     comments: result.data.comments
+//   };
+//   console.log(articleObj);
+//   res.render("newarticle", { articleObj, page: "newarticle" });
+// });
 
 app.listen(app.get("port"), () => {
   console.log("App running on port", app.get("port"));

--- a/src/views/newarticle.hbs
+++ b/src/views/newarticle.hbs
@@ -6,8 +6,11 @@
 </header>
 
 <div class="content">
-    <h1>Johnson to tell Juncker: ‘I won’t discuss Brexit extension beyond 31 October’</h1>
-    <h2>The Guardian</h2>
+    {{!-- <h1>Johnson to tell Juncker: ‘I won’t discuss Brexit extension beyond 31 October’</h1> --}}
+    <h1>{{{articleObj.title}}}</h1>
+    {{!-- TODO:
+        Make mapping of native siteNames to how we need them to appear on the page --}}
+    <h2>{{{articleObj.siteName}}}</h2>
     <div class="post-meta">
         <small>3 people talking about this</small>
     </div>


### PR DESCRIPTION
Works for The Sun, The Guardian, and The BBC.

For the New York Times, the article title works, but the siteName comes through as an empty string (#23)

